### PR TITLE
Resolve error AccessControlListNotSupported

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -75,6 +75,7 @@ resource "aws_s3_bucket_acl" "s3_reddit_bucket_acl" {
   bucket = aws_s3_bucket.reddit_bucket.id
   acl    = "private"
 
+  # NOTE: TO BE TESTED
   # Add by Yuzhen, start
   # Depends_on resource to avoid error "AccessControlListNotSupported: The bucket does not allow ACLs"
   depends_on = [aws_s3_bucket_ownership_controls.s3_bucket_acl_ownership]
@@ -82,6 +83,7 @@ resource "aws_s3_bucket_acl" "s3_reddit_bucket_acl" {
 
 }
 
+# NOTE: TO BE TESTED
 # Add by Yuzhen, start
 # Resource to avoid error "AccessControlListNotSupported: The bucket does not allow ACLs"
 resource "aws_s3_bucket_ownership_controls" "s3_bucket_acl_ownership" {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -25,7 +25,7 @@ resource "aws_redshift_cluster" "redshift" {
   publicly_accessible = "true"
   iam_roles = [aws_iam_role.redshift_role.arn]
   vpc_security_group_ids = [aws_security_group.sg_redshift.id]
-  
+
 }
 
 # Confuge security group for Redshift allowing all inbound/outbound traffic
@@ -74,5 +74,20 @@ resource "aws_s3_bucket" "reddit_bucket" {
 resource "aws_s3_bucket_acl" "s3_reddit_bucket_acl" {
   bucket = aws_s3_bucket.reddit_bucket.id
   acl    = "private"
+
+  # Add by Yuzhen, start
+  # Depends_on resource to avoid error "AccessControlListNotSupported: The bucket does not allow ACLs"
+  depends_on = [aws_s3_bucket_ownership_controls.s3_bucket_acl_ownership]
+  # Add by Yuzhen, end
+
 }
-      
+
+# Add by Yuzhen, start
+# Resource to avoid error "AccessControlListNotSupported: The bucket does not allow ACLs"
+resource "aws_s3_bucket_ownership_controls" "s3_bucket_acl_ownership" {
+  bucket = aws_s3_bucket.reddit_bucket.id
+  rule {
+    object_ownership = "ObjectWriter"
+  }
+}
+# Add by Yuzhen, end


### PR DESCRIPTION
When tried to deploy the aws_s3_bucket reddit_bucket resource using Terraform, then received the error: AccessControlListNotSupported.
Because with Terraform, the default value is BucketOwnerEnforced (The only one which doesn’t work for ACL). 
To solve this error: Set ownership to be created first, and put depends_on in the ACL resource to force the ownership to one value that let ACL resource be created.

Refrence: https://stackoverflow.com/questions/76049290/error-accesscontrollistnotsupported-when-trying-to-create-a-bucket-acl-in-aws